### PR TITLE
Replaced not supported BeginInvoke calls with Task.Run().

### DIFF
--- a/Request.cs
+++ b/Request.cs
@@ -65,8 +65,14 @@ namespace JulMarAtapi
             Result = resultCode;
             _timeStarted.Stop();
             _asyncWaitHandle.Set();
-            if (_callback != null)
-                _callback.BeginInvoke(this, ar => _callback.EndInvoke(ar), null);
+            if(_callback != null) {
+                Task.Run(() => {
+                    try {
+                        _callback(this);
+                    } catch {
+                    }
+                });
+            }
         }
 
         /// <summary>

--- a/TapiLine.cs
+++ b/TapiLine.cs
@@ -1677,22 +1677,24 @@ namespace JulMarAtapi
         {
             if (NewCall != null)
             {
-                Privilege priv = (callPrivileges == NativeMethods.LINECALLPRIVILEGE_NONE) ? Privilege.None :
-                    (callPrivileges == NativeMethods.LINECALLPRIVILEGE_MONITOR) ? Privilege.Monitor : Privilege.Owner;
-                foreach (EventHandler<NewCallEventArgs> nc in NewCall.GetInvocationList())
+                Privilege priv = callPrivileges switch 
                 {
-                    nc.BeginInvoke(this, new NewCallEventArgs(call, priv),
-                        delegate(IAsyncResult ar) 
+                    NativeMethods.LINECALLPRIVILEGE_NONE => Privilege.None,
+                    NativeMethods.LINECALLPRIVILEGE_MONITOR => Privilege.Monitor,
+                    _ => Privilege.Owner
+                };
+
+                foreach(EventHandler<NewCallEventArgs> nc in NewCall.GetInvocationList().Cast<EventHandler<NewCallEventArgs>>()) 
+                {
+                    Task.Run(() =>
+                    {
+                        try 
                         {
-                            try
-                            {
-                                var nce = (EventHandler<NewCallEventArgs>)ar.AsyncState;
-                                nce.EndInvoke(ar);
-                            }
-                            catch
-                            {
-                            }
-                        }, nc);
+                            nc.Invoke(this, new NewCallEventArgs(call, priv));
+                        } 
+                        catch {
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
.Net6 does not support BeginInvoke. I have replaced the 2 calls to BeginInvoke with Task.Run().